### PR TITLE
fix yj download url

### DIFF
--- a/stack/build.Dockerfile
+++ b/stack/build.Dockerfile
@@ -17,5 +17,5 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
 
 RUN for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done
 
-RUN curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux \
+RUN curl -sSfL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
   && chmod +x /usr/local/bin/yj


### PR DESCRIPTION
## Summary

Fix the URL (`-amd64` missing) and add curl options to fail in case of 404 or similar errors.

## Use Cases

Fix for buildpacks using `yj`

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
