### PR TITLE
Add universe and multiverse as package sources

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -13,9 +13,9 @@ platforms = ["linux/amd64"]
 
   [build.args]
     sources = """
-    deb http://archive.ubuntu.com/ubuntu jammy main
-    deb http://archive.ubuntu.com/ubuntu jammy-updates main
-    deb http://archive.ubuntu.com/ubuntu jammy-security main
+    deb http://archive.ubuntu.com/ubuntu jammy main universe multiverse
+    deb http://archive.ubuntu.com/ubuntu jammy-updates main universe multiverse
+    deb http://archive.ubuntu.com/ubuntu jammy-security main universe multiverse
     """
 
     packages = """\


### PR DESCRIPTION
## Context
In our stacks, we don't install any packages from the `universe` or `multiverse` repositories, so there was no need to include them as a package source.
Recently, we discovered that the compilation of the PHP dependency happens on the Bionic Full stack, and then requires installing some extra packages from the Ubuntu `multiverse` repository to work. 

This PR adds the `universe` and `multiverse` sources into the stack to enable use cases that leverage the stack with the addition of `multiverse` packages. **We will not be shipping any packages from the `multiverse` repository in the stacks themselves, and should not in the future.** This change is solely to enable others to do that.

In the future we should add some kind of test assertion here to ensure any new packages do not come from `multiverse`.
 
## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
