### PR TITLE
forbid the install of packages from multiverse

### DIFF
--- a/stack/build.Dockerfile
+++ b/stack/build.Dockerfile
@@ -5,6 +5,7 @@ ARG packages
 ARG package_args='--no-install-recommends'
 
 RUN echo "$sources" > /etc/apt/sources.list
+RUN echo "Package: $packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: $packages\nPin: release c=restricted\nPin-Priority: -1\n" > /etc/apt/preferences
 
 RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selections && \
   export DEBIAN_FRONTEND=noninteractive && \
@@ -14,7 +15,7 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   locale-gen en_US.UTF-8 && \
   update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
   apt-get -y $package_args install $packages && \
-  rm -rf /var/lib/apt/lists/* /tmp/*
+  rm -rf /var/lib/apt/lists/* /tmp/* /etc/apt/preferences
 
 RUN for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done
 

--- a/stack/run/run.Dockerfile
+++ b/stack/run/run.Dockerfile
@@ -12,6 +12,7 @@ ADD files/nsswitch.conf /tiny/etc/nsswitch.conf
 ADD files/group /tiny/etc/group
 
 RUN mkdir -p /tiny/tmp /tiny/var/lib/dpkg/status.d/
+RUN echo "Package: $packages\nPin: release c=multiverse\nPin-Priority: -1\n\nPackage: $packages\nPin: release c=restricted\nPin-Priority: -1\n" > /etc/apt/preferences
 
 # We can't use dpkg -i (even with --instdir=/tiny) because we don't want to
 # install the dependencies, and dpkg-deb has no way to ignore all dependencies;


### PR DESCRIPTION
## Summary
This prevents packages can be installed from `multiverse` or `restricted` for both, `build` and `run` images. Prior discussions and reasoning can be found at https://github.com/paketo-buildpacks/bionic-tiny-stack/issues/40.
I'd use this PR as a blueprint for all other stacks once it is ready.
## Use Cases
See https://github.com/paketo-buildpacks/bionic-tiny-stack/issues/40 and https://github.com/paketo-buildpacks/bionic-tiny-stack/pull/39.
## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).