### PR TITLE
Push docker manifest list to gcr instead of oci format

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
     - name: Download Build Image
       uses: paketo-buildpacks/github-config/actions/release/download-asset@main
       with:
@@ -70,14 +73,20 @@ jobs:
         ./scripts/publish.sh \
           --build-ref "docker.io/${DOCKERHUB_ORG}/build-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}" \
           --build-ref "docker.io/${DOCKERHUB_ORG}/build-${{ steps.registry-repo.outputs.name }}:latest" \
-          --build-ref "gcr.io/${GCR_PROJECT}/build-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}" \
-          --build-ref "gcr.io/${GCR_PROJECT}/build-${{ steps.registry-repo.outputs.name }}:latest" \
           --run-ref "docker.io/${DOCKERHUB_ORG}/run-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}" \
           --run-ref "docker.io/${DOCKERHUB_ORG}/run-${{ steps.registry-repo.outputs.name }}:latest" \
-          --run-ref "gcr.io/${GCR_PROJECT}/run-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}" \
-          --run-ref "gcr.io/${GCR_PROJECT}/run-${{ steps.registry-repo.outputs.name }}:latest" \
           --build-archive "${GITHUB_WORKSPACE}/build.oci" \
           --run-archive "${GITHUB_WORKSPACE}/run.oci"
+
+        for imageType in build run; do
+          echo "FROM docker.io/${DOCKERHUB_ORG}/${imageType}-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}" | \
+          docker buildx build -f - . \
+            --tag "gcr.io/${GCR_PROJECT}/${imageType}-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}" \
+            --tag "gcr.io/${GCR_PROJECT}/${imageType}-${{ steps.registry-repo.outputs.name }}:latest" \
+            --platform linux/amd64,linux/arm64 \
+            --provenance=false \
+            --push
+        done
 
         # If the repository name contains 'bionic', let's push it to legacy image locations as well:
         #    paketobuildpacks/{build/run}:{version}-{variant}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change modifies the push-image workflow so that the multi-arch images that are pushed to gcr.io are of the `application/vnd.docker.distribution.manifest.list.v2+json` media type. This is necessary because gcr does not support oci manifest lists, but I did find a public multi-arch gcr image using the docker manifest type. See below.

```
crane manifest gcr.io/google-containers/kube-proxy:v1.19.0-rc.1 | jq
```

## Testing

The manual testing shown below validates creating and pushing the `docker` format manifest list. It does not test pushing to gcr, but I think having found a multi-arch image in gcr means it will work.

Here I create the `docker` format manifest list and push the multi-arch image to ttl.sh (for testing purposes).

```
➜  ~ echo "FROM paketobuildpacks/run-jammy-tiny:0.2.0" | docker buildx build -f - . -t ttl.sh/run-jammy-tiny:docker-manifest --platform linux/amd64,linux/arm64 --provenance=false --push 
[+] Building 25.3s (8/8) FINISHED                                                                                                                               
 => [internal] load .dockerignore                                                                                                                          0.2s
 => => transferring context: 2B                                                                                                                            0.1s
 => [internal] load build definition from Dockerfile                                                                                                       0.0s
 => => transferring dockerfile: 117B                                                                                                                       0.0s
 => [linux/arm64 internal] load metadata for docker.io/paketobuildpacks/run-jammy-tiny:0.2.0                                                               2.2s
 => [linux/amd64 internal] load metadata for docker.io/paketobuildpacks/run-jammy-tiny:0.2.0                                                               2.2s
 => [auth] paketobuildpacks/run-jammy-tiny:pull token for registry-1.docker.io                                                                             0.0s
 => [linux/amd64 1/1] FROM docker.io/paketobuildpacks/run-jammy-tiny:0.2.0@sha256:65572c6ce47ab448af24fd6518d923042bfda4180666868c7806af672f5f11fc         1.4s
 => => resolve docker.io/paketobuildpacks/run-jammy-tiny:0.2.0@sha256:65572c6ce47ab448af24fd6518d923042bfda4180666868c7806af672f5f11fc                     0.0s
 => => sha256:f6a49e8798822c7d4300126ff2ac9e7e713837b0f3f8b284cf5318b70d657ecb 421B / 421B                                                                 0.1s
 => => sha256:cd7ad981ef72352e7bad54a9016650b26b2e7fb8e52b51ced7ee9c644a2d62ab 300B / 300B                                                                 0.1s
 => => sha256:61e65d7beb4e2fce9093801faf3b34e1a64a0d8028735e9b353d73a668944250 10.04MB / 10.04MB                                                           1.1s
 => [linux/arm64 1/1] FROM docker.io/paketobuildpacks/run-jammy-tiny:0.2.0@sha256:65572c6ce47ab448af24fd6518d923042bfda4180666868c7806af672f5f11fc         2.5s
 => => resolve docker.io/paketobuildpacks/run-jammy-tiny:0.2.0@sha256:65572c6ce47ab448af24fd6518d923042bfda4180666868c7806af672f5f11fc                     0.0s
 => => sha256:de35265d65bef43634bb9e23fc4a98831f6e8ad5d4bbb04279231f66d45d26fe 299B / 299B                                                                 0.1s
 => => sha256:5d770d79fa28347491e514169706df2c944748281d5e7876e2a42cab5aa53bea 445B / 445B                                                                 0.2s
 => => sha256:055b7b5e8545b601664dbdb7b98288df88cd5f970d1b76bc2654ab314c25845b 8.45MB / 8.45MB                                                             2.2s
 => exporting to image                                                                                                                                    22.8s
 => => exporting layers                                                                                                                                    0.0s
 => => exporting manifest sha256:c5c2faaec21b152d0ba6a7d99cf7babd4dd495cec8a4818e7f58b5a549be3855                                                          0.0s
 => => exporting config sha256:04a5a2a71be262ee02048776a92c50306c5b02cd36a2654ac91ae502497d9f5e                                                            0.0s
 => => exporting manifest sha256:1b2beb8f1332f7bd00b16b43166defa4f2095a6ebc640e83f3b363da339b3d42                                                          0.0s
 => => exporting config sha256:61245ef45430d150c366c77b7ad5e50b7d2a26980335b631e338c567c0fcfc08                                                            0.0s
 => => exporting manifest list sha256:621b3f69f2832e341ae91301a700dbf1e0e5b38cc6bd3b0eea784a7a43ed5751                                                     0.0s
 => => pushing layers                                                                                                                                     20.1s
 => => pushing manifest for ttl.sh/run-jammy-tiny:docker-manifest@sha256:621b3f69f2832e341ae91301a700dbf1e0e5b38cc6bd3b0eea784a7a43ed5751                  2.7s
➜  ~ 
```

Here you can see the correct media type for the manifest that is pushed.

```
➜  ~ crane manifest ttl.sh/run-jammy-tiny:docker-manifest | jq
{
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "digest": "sha256:c5c2faaec21b152d0ba6a7d99cf7babd4dd495cec8a4818e7f58b5a549be3855",
      "size": 892,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "digest": "sha256:1b2beb8f1332f7bd00b16b43166defa4f2095a6ebc640e83f3b363da339b3d42",
      "size": 891,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}
➜  ~ 
```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
