### PR TITLE
Add setup-buildx-action for push-image workflow

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
 
+    - name: Set up buildx
+      uses: docker/setup-buildx-action@v2
+
     - name: Download Build Image
       uses: paketo-buildpacks/github-config/actions/release/download-asset@main
       if: github.event.inputs.version == ''


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change adds the `setup-buildx-action` to the push-image workflow. I mistakenly thought the `setup-qemu-action` also configured buildx but that is not the case. The workflow failed with the following error because a multi-platform [buildx] builder was not configured and it defaulted back to the docker driver (daemon).

`ERROR: Multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx cr`

## Testing

The workflow should work with the `setup-buildx-action` in place. It's hard to test, but the following workflow in one of my repos uses the action and it works correctly.

https://github.com/jericop/cnb-builder/blob/main/.github/workflows/pull_request.yml#L15C7-L15C44

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
