### PR TITLE
Fix broken if statement in push-image workflow.

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -19,7 +19,10 @@ jobs:
     - name: Parse Event
       id: event
       run: |
-        if ${{ github.event.inputs.version }} == ''; then
+        set -euo pipefail
+        shopt -s inherit_errexit
+
+        if [[ ${{ github.event.inputs.version }} == '' ]]; then
           echo "tag=$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)" >> "$GITHUB_OUTPUT"
         else
           echo "tag=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The recent changes to the push-image workflow have a broken syntax. This PR fixes that.

Additionally, it adds error handling so we can catch and view issues like this.

## Use Cases

The workflow run [here](https://github.com/paketo-buildpacks/jammy-tiny-stack/actions/runs/5957091439/job/16159133542) incorrectly succeeds, but any invocation that wasn't manually triggered will silently fail to get the version from the github even.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
