### PR TITLE
Push image: add quotes around input version

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -22,7 +22,7 @@ jobs:
         set -euo pipefail
         shopt -s inherit_errexit
 
-        if [[ ${{ github.event.inputs.version }} == '' ]]; then
+        if [[ "${{ github.event.inputs.version }}" == '' ]]; then
           echo "tag=$(jq -r '.release.tag_name' "${GITHUB_EVENT_PATH}" | sed s/^v//)" >> "$GITHUB_OUTPUT"
         else
           echo "tag=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
resolves remaining failures related to #38 
Add quotes around the workflow dispatch input version variable so that the workflow does not fail out when no version is passed in which occurs when the workflow is triggered by the release workflow 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
