### PR TITLE
Update GitHub Actions to use upload-artifact and download-artifact v4

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -194,13 +194,13 @@ jobs:
         ./scripts/create.sh
 
     - name: Upload run image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: current-run-image
         path: build/run.oci
 
     - name: Upload build image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: current-build-image
         path: build/build.oci
@@ -214,13 +214,13 @@ jobs:
                             --run-receipt ${{ env.RUN_RECEIPT_FILENAME }}
 
     - name: Upload ${{ matrix.arch }} Build receipt(s)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: current-build-receipt
         path: "*${{ env.BUILD_RECEIPT_FILENAME }}"
 
     - name: Upload ${{ matrix.arch }} Run receipt(s)
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: current-run-receipt
         path: "*${{ env.RUN_RECEIPT_FILENAME }}"
@@ -243,12 +243,12 @@ jobs:
         arch: ${{ fromJSON(needs.get_architectures.outputs.architectures) }}
     steps:
     - name: Download Build Receipt
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-build-receipt
 
     - name: Download Run Receipt
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-run-receipt
 
@@ -420,13 +420,13 @@ jobs:
         mkdir -p build
 
     - name: Download Build Image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-build-image
         path: build
 
     - name: Download Run Image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-run-image
         path: build
@@ -464,22 +464,22 @@ jobs:
         fetch-depth: 0  # gets full history
 
     - name: Download current build image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-build-image
 
     - name: Download current run image
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-run-image
 
     - name: Download Build Receipt
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-build-receipt
 
     - name: Download Run Receipt
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: current-run-receipt
 

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: event-payload
         path: ${{ github.event_path }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Upgrade deprecated artifacts actions, that stopped working on January 30th 2025 ([source](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)).

Closes #32 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
