### PR TITLE
Switch to packages json file because list is too long for command line

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,7 @@ concurrency: release
 env:
   BUILD_RECEIPT_FILENAME: "build-receipt.cyclonedx.json"
   RUN_RECEIPT_FILENAME: "run-receipt.cyclonedx.json"
+  PACKAGES_FILENAME: "packages.json"
   PATCHED_USNS_FILENAME: "patched-usns.json"
   BUILD_DIFF_ADDED_FILENAME: "build-diff-added.json"
   BUILD_DIFF_MODIFIED_FILENAME: "build-diff-modified.json"
@@ -93,6 +94,7 @@ jobs:
       with:
         build_receipt: "${{ github.workspace }}/${{ matrix.arch }}-${{ env.BUILD_RECEIPT_FILENAME }}"
         run_receipt: "${{ github.workspace }}/${{ matrix.arch }}-${{ env.RUN_RECEIPT_FILENAME }}"
+        output_path: "${{ github.workspace }}/${{ matrix.arch }}-${{ env.PACKAGES_FILENAME }}"
 
     - name: Find and Download Previous Patched USNs
       id: download_patched
@@ -125,7 +127,7 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/stack/get-usns@main
       with:
         distribution: ${{ steps.distro.outputs.distro }}
-        packages: ${{ steps.packages.outputs.packages }}
+        packages_filepath: "/github/workspace/${{ matrix.arch }}-${{ env.PACKAGES_FILENAME }}"
         last_usns: ${{ steps.patched.outputs.patched }}
 
     - name: Write USNs File


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The package list became too long and the create-release action would fail as a result. Switching to a json file resolves the issue.

The change has been tested and verified in the following fork of jammy-tiny-stack with releases created to verify everything works as expected.

This run created release [v1.2.0](https://github.com/jericop/jammy-tiny-stack/releases/tag/v1.2.0) and finished successfully. Subsequent runs are also now finishing successfully.
https://github.com/jericop/jammy-tiny-stack/actions/runs/14609567123

## Use Cases
<!-- An explanation of the use cases your change enables -->

fixes https://github.com/paketo-buildpacks/jammy-tiny-stack/issues/182

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
