### PR TITLE
Added md5sums and cleaned up the list files for dpkg packages

### DIFF
--- a/metadata_test.go
+++ b/metadata_test.go
@@ -221,6 +221,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/base-files.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/ca-certificates", SatisfyAll(
 				ContainSubstring("Package: ca-certificates"),
 				MatchRegexp("Version: [0-9]+"),
@@ -230,6 +232,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/ca-certificates.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/ca-certificates.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/libc6", SatisfyAll(
 				ContainSubstring("Package: libc6"),
@@ -243,6 +247,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/libc6.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/libssl3", SatisfyAll(
 				ContainSubstring("Package: libssl3"),
 				MatchRegexp("Version: [0-9\\.\\-]+ubuntu[0-9\\.]+"),
@@ -255,6 +261,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/libssl3.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/netbase", SatisfyAll(
 				ContainSubstring("Package: netbase"),
 				MatchRegexp("Version: [0-9\\.]+"),
@@ -264,6 +272,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/netbase.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/netbase.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/openssl", SatisfyAll(
 				ContainSubstring("Package: openssl"),
@@ -277,6 +287,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("/."),
 			)))
 
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/openssl.md5sums"))
+
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/tzdata", SatisfyAll(
 				ContainSubstring("Package: tzdata"),
 				MatchRegexp("Version: [a-z0-9\\.\\-]+ubuntu[0-9\\.]+"),
@@ -286,6 +298,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/tzdata.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/tzdata.md5sums"))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/status.d/zlib1g", SatisfyAll(
 				ContainSubstring("Package: zlib1g"),
@@ -298,6 +312,8 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/zlib1g.list", SatisfyAll(
 				ContainSubstring("/."),
 			)))
+
+			Expect(image).To(HaveFile("/var/lib/dpkg/info/zlib1g.md5sums"))
 
 			Expect(image).NotTo(HaveFile("/usr/share/ca-certificates"))
 


### PR DESCRIPTION
## Summary
This is a continuation of scanner related issues with the tiny image. This change does the following

- Cleans up the list file creation by doing 3 steps
  - Creates the list file using `dpkg-deb -c $pkg*.deb | awk '{print substr($6, 2)}'`
  - Replaces the first line with "/."
  - Removes the final "/" from all lines that end with a "/"
- Creates the $pkg.md5sums file by using the command `dpkg-deb -e $pkg*.deb MD5SUMS`
- Added test cases to address these changes.

This PR should address what is mentioned in the following issue (https://github.com/paketo-buildpacks/jammy-tiny-stack/issues/153)

## Use Cases
These changes will hopefully address the issues from scanning tiny images with false positives with CVEs.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
