### PR TITLE
Add the libstdc++6 & libgcc-s1 packages

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -66,6 +66,8 @@ platforms = ["linux/amd64", "linux/arm64"]
     openssl \
     tzdata \
     zlib1g \
+    libstdc++6 \
+    libgcc-s1
     """
 
   [run.platforms."linux/arm64".args]


### PR DESCRIPTION
This is in accordance with https://github.com/paketo-buildpacks/rfcs/blob/main/text/stacks/0006-node-on-tiny.md which was accepted previously.

Backporting this to Jammy: https://github.com/paketo-buildpacks/ubuntu-noble-base-images/pull/58