### PR TITLE
feat: add s390x and ppc64le support

### DIFF
--- a/buildpack_integration_test.go
+++ b/buildpack_integration_test.go
@@ -91,6 +91,14 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 [[targets]]
   arch = "arm64"
   os = "linux"
+
+[[targets]]
+  arch = "s390x"
+  os = "linux"
+
+[[targets]]
+  arch = "ppc64le"
+  os = "linux"
 `,
 			stack.BuildImageID,
 			stack.RunImageID,

--- a/images.json
+++ b/images.json
@@ -1,7 +1,7 @@
 {
     "support_usns": true,
     "receipts_show_limit": 16,
-    "platforms": ["linux/amd64", "linux/arm64"],
+    "platforms": ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"],
     "os_name": "ubuntu",
     "os_codename": "jammy",
     "repo_type": "stack",

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -57,7 +57,7 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			indexManifest, err := index.IndexManifest()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(indexManifest.Manifests).To(HaveLen(2))
+			Expect(indexManifest.Manifests).To(HaveLen(4))
 
 			platforms := []v1.Platform{}
 			for _, manifest := range indexManifest.Manifests {
@@ -73,6 +73,14 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(platforms).To(ContainElement(v1.Platform{
 				OS:           "linux",
 				Architecture: "arm64",
+			}))
+			Expect(platforms).To(ContainElement(v1.Platform{
+				OS:           "linux",
+				Architecture: "s390x",
+			}))
+			Expect(platforms).To(ContainElement(v1.Platform{
+				OS:           "linux",
+				Architecture: "ppc64le",
 			}))
 
 			image, err := index.Image(indexManifest.Manifests[0].Digest)
@@ -155,7 +163,7 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			indexManifest, err := index.IndexManifest()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(indexManifest.Manifests).To(HaveLen(2))
+			Expect(indexManifest.Manifests).To(HaveLen(4))
 			platforms := []v1.Platform{}
 			for _, manifest := range indexManifest.Manifests {
 				platforms = append(platforms, v1.Platform{
@@ -170,6 +178,14 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(platforms).To(ContainElement(v1.Platform{
 				OS:           "linux",
 				Architecture: "arm64",
+			}))
+			Expect(platforms).To(ContainElement(v1.Platform{
+				OS:           "linux",
+				Architecture: "s390x",
+			}))
+			Expect(platforms).To(ContainElement(v1.Platform{
+				OS:           "linux",
+				Architecture: "ppc64le",
 			}))
 
 			image, err := index.Image(indexManifest.Manifests[0].Digest)
@@ -214,7 +230,9 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp("Version: [0-9]+ubuntu[0-9\\.]+"),
 				SatisfyAny(
 					ContainSubstring("Architecture: amd64"),
-					ContainSubstring("Architecture: arm64")),
+					ContainSubstring("Architecture: arm64"),
+					ContainSubstring("Architecture: s390x"),
+					ContainSubstring("Architecture: ppc64le")),
 			)))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/base-files.list", SatisfyAll(
@@ -240,7 +258,9 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp("Version: [0-9\\.\\-]+ubuntu[0-9\\.]+"),
 				SatisfyAny(
 					ContainSubstring("Architecture: amd64"),
-					ContainSubstring("Architecture: arm64")),
+					ContainSubstring("Architecture: arm64"),
+					ContainSubstring("Architecture: s390x"),
+					ContainSubstring("Architecture: ppc64le")),
 			)))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/libc6.list", SatisfyAll(
@@ -254,7 +274,9 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp("Version: [0-9\\.\\-]+ubuntu[0-9\\.]+"),
 				SatisfyAny(
 					ContainSubstring("Architecture: amd64"),
-					ContainSubstring("Architecture: arm64")),
+					ContainSubstring("Architecture: arm64"),
+					ContainSubstring("Architecture: s390x"),
+					ContainSubstring("Architecture: ppc64le")),
 			)))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/libssl3.list", SatisfyAll(
@@ -280,7 +302,9 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp("Version: [0-9\\.\\-]+ubuntu[0-9\\.]+"),
 				SatisfyAny(
 					ContainSubstring("Architecture: amd64"),
-					ContainSubstring("Architecture: arm64")),
+					ContainSubstring("Architecture: arm64"),
+					ContainSubstring("Architecture: s390x"),
+					ContainSubstring("Architecture: ppc64le")),
 			)))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/openssl.list", SatisfyAll(
@@ -306,7 +330,9 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp("Version: [a-z0-9\\.\\-\\:]+ubuntu[0-9\\.]+"),
 				SatisfyAny(
 					ContainSubstring("Architecture: amd64"),
-					ContainSubstring("Architecture: arm64")),
+					ContainSubstring("Architecture: arm64"),
+					ContainSubstring("Architecture: s390x"),
+					ContainSubstring("Architecture: ppc64le")),
 			)))
 
 			Expect(image).To(HaveFileWithContent("/var/lib/dpkg/info/zlib1g.list", SatisfyAll(

--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -2,7 +2,7 @@ id = "io.buildpacks.stacks.jammy.tiny"
 homepage = "https://github.com/paketo-buildpacks/jammy-tiny-stack"
 maintainer = "Paketo Buildpacks"
 
-platforms = ["linux/amd64", "linux/arm64"]
+platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
 
 [build]
   description = "ubuntu:jammy with compilers and shell utilities"
@@ -47,6 +47,24 @@ platforms = ["linux/amd64", "linux/arm64"]
     deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe multiverse
     """
 
+  [build.platforms."linux/s390x".args]
+    architecture = "s390x"
+
+    sources = """
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe multiverse
+    """
+
+  [build.platforms."linux/ppc64le".args]
+    architecture = "ppc64le"
+
+    sources = """
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe multiverse
+    """
+
 [run]
   description = "distroless-like jammy"
   dockerfile = "./run/run.Dockerfile"
@@ -72,6 +90,24 @@ platforms = ["linux/amd64", "linux/arm64"]
 
   [run.platforms."linux/arm64".args]
     architecture = "arm64"
+
+    sources = """
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe multiverse
+    """
+
+  [run.platforms."linux/s390x".args]
+    architecture = "s390x"
+
+    sources = """
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe multiverse
+    deb http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe multiverse
+    """
+
+  [run.platforms."linux/ppc64le".args]
+    architecture = "ppc64le"
 
     sources = """
     deb http://ports.ubuntu.com/ubuntu-ports/ jammy main universe multiverse


### PR DESCRIPTION
## Summary
This PR adds support for the `s390x` (IBM Z) and `ppc64le` (PowerPC 64-bit Little Endian) architectures to the `jammy-tiny` stack. It updates the stack definition (`stack.toml`), internal tooling (`scripts/.util/tools.sh`), and `images.json` to include these new architectures. It also extends the metadata and buildpack integration tests to verify successful builds for both platforms.

## Use Cases
This change enables Paketo Buildpacks users to build, run, and deploy applications on IBM Z and PowerPC architectures using the `jammy-tiny` stack, expanding the platform compatibility footprint for multi-architecture deployments.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

